### PR TITLE
[WIP] Graphite Tagging Support

### DIFF
--- a/src/utils_format_graphite.c
+++ b/src/utils_format_graphite.c
@@ -97,6 +97,86 @@ static void gr_copy_escape_part(char *dst, const char *src, size_t dst_len,
   }
 }
 
+static int gr_format_name_tagged(char *ret, int ret_len, value_list_t const *vl,
+                                 char const *ds_name, char const *prefix,
+                                 char const *postfix, char const escape_char,
+                                 unsigned int flags) {
+  char n_host[DATA_MAX_NAME_LEN];
+  char n_plugin[DATA_MAX_NAME_LEN];
+  char n_plugin_instance[DATA_MAX_NAME_LEN];
+  char n_type[DATA_MAX_NAME_LEN];
+  char n_type_instance[DATA_MAX_NAME_LEN];
+
+  char tmp_plugin[DATA_MAX_NAME_LEN + 8];
+  char tmp_plugin_instance[DATA_MAX_NAME_LEN + 17];
+  char tmp_type[DATA_MAX_NAME_LEN + 6];
+  char tmp_type_instance[DATA_MAX_NAME_LEN + 15];
+  char tmp_metric[3 * DATA_MAX_NAME_LEN + 2];
+  char tmp_ds_name[DATA_MAX_NAME_LEN + 9];
+
+  if (prefix == NULL)
+    prefix = "";
+
+  if (postfix == NULL)
+    postfix = "";
+
+  gr_copy_escape_part(n_host, vl->host, sizeof(n_host), escape_char, 1);
+  gr_copy_escape_part(n_plugin, vl->plugin, sizeof(n_plugin), escape_char, 1);
+  gr_copy_escape_part(n_plugin_instance, vl->plugin_instance,
+                      sizeof(n_plugin_instance), escape_char, 1);
+  gr_copy_escape_part(n_type, vl->type, sizeof(n_type), escape_char, 1);
+  gr_copy_escape_part(n_type_instance, vl->type_instance,
+                      sizeof(n_type_instance), escape_char, 1);
+
+  snprintf(tmp_plugin, sizeof(tmp_plugin), ";plugin=%s", n_plugin);
+
+  if (n_plugin_instance[0] != '\0')
+    snprintf(tmp_plugin_instance, sizeof(tmp_plugin_instance),
+             ";plugin_instance=%s", n_plugin_instance);
+  else
+    tmp_plugin_instance[0] = '\0';
+
+  if (!(flags & GRAPHITE_DROP_DUPE_FIELDS) || strcmp(n_plugin, n_type) != 0)
+    snprintf(tmp_type, sizeof(tmp_type), ";type=%s", n_type);
+  else
+    tmp_type[0] = '\0';
+
+  if (n_type_instance[0] != '\0') {
+    if (!(flags & GRAPHITE_DROP_DUPE_FIELDS) ||
+        strcmp(n_plugin_instance, n_type_instance) != 0)
+      snprintf(tmp_type_instance, sizeof(tmp_type_instance),
+               ";type_instance=%s", n_type_instance);
+    else
+      tmp_type_instance[0] = '\0';
+  } else
+    tmp_type_instance[0] = '\0';
+
+  /* Assert always_append_ds -> ds_name */
+  assert(!(flags & GRAPHITE_ALWAYS_APPEND_DS) || (ds_name != NULL));
+  if (ds_name != NULL) {
+    snprintf(tmp_ds_name, sizeof(tmp_ds_name), ";ds_name=%s", ds_name);
+
+    if ((flags & GRAPHITE_DROP_DUPE_FIELDS) && strcmp(n_plugin, n_type) == 0)
+      snprintf(tmp_metric, sizeof(tmp_metric), "%s.%s", n_plugin, ds_name);
+    else
+      snprintf(tmp_metric, sizeof(tmp_metric), "%s.%s.%s", n_plugin, n_type,
+               ds_name);
+  } else {
+    tmp_ds_name[0] = '\0';
+
+    if ((flags & GRAPHITE_DROP_DUPE_FIELDS) && strcmp(n_plugin, n_type) == 0)
+      snprintf(tmp_metric, sizeof(tmp_metric), "%s", n_plugin);
+    else
+      snprintf(tmp_metric, sizeof(tmp_metric), "%s.%s", n_plugin, n_type);
+  }
+
+  snprintf(ret, ret_len, "%s%s%s;host=%s%s%s%s%s%s", prefix, tmp_metric,
+           postfix, n_host, tmp_plugin, tmp_plugin_instance, tmp_type,
+           tmp_type_instance, tmp_ds_name);
+
+  return 0;
+}
+
 static int gr_format_name(char *ret, int ret_len, value_list_t const *vl,
                           char const *ds_name, char const *prefix,
                           char const *postfix, char const escape_char,
@@ -199,15 +279,26 @@ int format_graphite(char *buffer, size_t buffer_size, data_set_t const *ds,
       ds_name = ds->ds[i].name;
 
     /* Copy the identifier to `key' and escape it. */
-    status = gr_format_name(key, sizeof(key), vl, ds_name, prefix, postfix,
-                            escape_char, flags);
-    if (status != 0) {
-      ERROR("format_graphite: error with gr_format_name");
-      sfree(rates);
-      return status;
+    if (flags & GRAPHITE_USE_TAGS) {
+      status = gr_format_name_tagged(key, sizeof(key), vl, ds_name, prefix,
+                                     postfix, escape_char, flags);
+      if (status != 0) {
+        ERROR("format_graphite: error with gr_format_name_tagged");
+        sfree(rates);
+        return status;
+      }
+    } else {
+      status = gr_format_name(key, sizeof(key), vl, ds_name, prefix, postfix,
+                              escape_char, flags);
+      if (status != 0) {
+        ERROR("format_graphite: error with gr_format_name");
+        sfree(rates);
+        return status;
+      }
     }
 
     escape_graphite_string(key, escape_char);
+
     /* Convert the values to an ASCII representation and put that into
      * `values'. */
     status = gr_format_values(values, sizeof(values), i, ds, vl, rates);

--- a/src/utils_format_graphite.h
+++ b/src/utils_format_graphite.h
@@ -31,6 +31,7 @@
 #define GRAPHITE_ALWAYS_APPEND_DS 0x04
 #define GRAPHITE_DROP_DUPE_FIELDS 0x08
 #define GRAPHITE_PRESERVE_SEPARATOR 0x10
+#define GRAPHITE_USE_TAGS 0x20
 
 int format_graphite(char *buffer, size_t buffer_size, const data_set_t *ds,
                     const value_list_t *vl, const char *prefix,

--- a/src/utils_format_graphite_test.c
+++ b/src/utils_format_graphite_test.c
@@ -124,6 +124,22 @@ DEF_TEST(metric_name) {
           .suffix = NULL,
           .want_name = "foo.example@com.test.single",
       },
+      /* flag GRAPHITE_USE_TAGS */
+      {.flags = GRAPHITE_USE_TAGS,
+       .want_name = "test.single;host=example.com;plugin=test;type=single"},
+      {.plugin_instance = "f.o.o",
+       .type_instance = "b.a.r",
+       .flags = GRAPHITE_USE_TAGS,
+       .want_name = "test.single;host=example.com;plugin=test;plugin_instance="
+                    "f.o.o;type=single;type_instance=b.a.r"},
+      {.flags = GRAPHITE_USE_TAGS ^ GRAPHITE_ALWAYS_APPEND_DS,
+       .want_name = "test.single.value;host=example.com;plugin=test;type="
+                    "single;ds_name=value"},
+      {.plugin_instance = "foo",
+       .type_instance = "foo",
+       .flags = GRAPHITE_USE_TAGS ^ GRAPHITE_DROP_DUPE_FIELDS,
+       .want_name = "test.single;host=example.com;plugin=test;plugin_instance="
+                    "foo;type=single"},
   };
 
   for (size_t i = 0; i < STATIC_ARRAY_SIZE(cases); i++) {

--- a/src/write_graphite.c
+++ b/src/write_graphite.c
@@ -38,6 +38,7 @@
  *     Protocol "udp"
  *     LogSendErrors true
  *     Prefix "collectd"
+ *     UseTags true
  *   </Carbon>
  * </Plugin>
  */
@@ -518,6 +519,8 @@ static int wg_config_node(oconfig_item_t *ci) {
       cf_util_get_flag(child, &cb->format_flags, GRAPHITE_PRESERVE_SEPARATOR);
     else if (strcasecmp("DropDuplicateFields", child->key) == 0)
       cf_util_get_flag(child, &cb->format_flags, GRAPHITE_DROP_DUPE_FIELDS);
+    else if (strcasecmp("UseTags", child->key) == 0)
+      cf_util_get_flag(child, &cb->format_flags, GRAPHITE_USE_TAGS);
     else if (strcasecmp("EscapeCharacter", child->key) == 0)
       config_set_char(&cb->escape_char, child);
     else {


### PR DESCRIPTION
Right now this produces output like:
```
collectd.collectd.cache_size.value;ds_name=value;host=raintank-dev;plugin=collectd;plugin_instance=cache;type=cache_size
collectd.collectd.derive.value;ds_name=value;host=raintank-dev;plugin=collectd;plugin_instance=write_queue;type=derive;type_instance=dropped
collectd.collectd.queue_length.value;ds_name=value;host=raintank-dev;plugin=collectd;plugin_instance=write_queue;type=queue_length

collectd.cpu.value;ds_name=value;host=raintank-dev;plugin=cpu;plugin_instance=0;type_instance=idle
collectd.cpu.value;ds_name=value;host=raintank-dev;plugin=cpu;plugin_instance=0;type_instance=interrupt
collectd.cpu.value;ds_name=value;host=raintank-dev;plugin=cpu;plugin_instance=0;type_instance=nice
collectd.cpu.value;ds_name=value;host=raintank-dev;plugin=cpu;plugin_instance=0;type_instance=softirq
collectd.cpu.value;ds_name=value;host=raintank-dev;plugin=cpu;plugin_instance=0;type_instance=steal
collectd.cpu.value;ds_name=value;host=raintank-dev;plugin=cpu;plugin_instance=0;type_instance=system
collectd.cpu.value;ds_name=value;host=raintank-dev;plugin=cpu;plugin_instance=0;type_instance=user
collectd.cpu.value;ds_name=value;host=raintank-dev;plugin=cpu;plugin_instance=0;type_instance=wait
collectd.cpu.value;ds_name=value;host=raintank-dev;plugin=cpu;plugin_instance=1;type_instance=idle
collectd.cpu.value;ds_name=value;host=raintank-dev;plugin=cpu;plugin_instance=1;type_instance=interrupt
collectd.cpu.value;ds_name=value;host=raintank-dev;plugin=cpu;plugin_instance=1;type_instance=nice
collectd.cpu.value;ds_name=value;host=raintank-dev;plugin=cpu;plugin_instance=1;type_instance=softirq
collectd.cpu.value;ds_name=value;host=raintank-dev;plugin=cpu;plugin_instance=1;type_instance=steal
collectd.cpu.value;ds_name=value;host=raintank-dev;plugin=cpu;plugin_instance=1;type_instance=system
collectd.cpu.value;ds_name=value;host=raintank-dev;plugin=cpu;plugin_instance=1;type_instance=user
collectd.cpu.value;ds_name=value;host=raintank-dev;plugin=cpu;plugin_instance=1;type_instance=wait

collectd.df.df_complex.value;ds_name=value;host=raintank-dev;plugin=df;plugin_instance=boot;type=df_complex;type_instance=free
collectd.df.df_complex.value;ds_name=value;host=raintank-dev;plugin=df;plugin_instance=boot;type=df_complex;type_instance=reserved
collectd.df.df_complex.value;ds_name=value;host=raintank-dev;plugin=df;plugin_instance=boot;type=df_complex;type_instance=used
collectd.df.df_complex.value;ds_name=value;host=raintank-dev;plugin=df;plugin_instance=dev;type=df_complex;type_instance=free
collectd.df.df_complex.value;ds_name=value;host=raintank-dev;plugin=df;plugin_instance=dev;type=df_complex;type_instance=reserved
collectd.df.df_complex.value;ds_name=value;host=raintank-dev;plugin=df;plugin_instance=dev;type=df_complex;type_instance=used
collectd.df.df_complex.value;ds_name=value;host=raintank-dev;plugin=df;plugin_instance=dev-shm;type=df_complex;type_instance=reserved
collectd.df.df_complex.value;ds_name=value;host=raintank-dev;plugin=df;plugin_instance=dev-shm;type=df_complex;type_instance=used
collectd.df.df_complex.value;ds_name=value;host=raintank-dev;plugin=df;plugin_instance=root;type=df_complex;type_instance=free
collectd.df.df_complex.value;ds_name=value;host=raintank-dev;plugin=df;plugin_instance=root;type=df_complex;type_instance=reserved
collectd.df.df_complex.value;ds_name=value;host=raintank-dev;plugin=df;plugin_instance=root;type=df_complex;type_instance=used
collectd.df.df_complex.value;ds_name=value;host=raintank-dev;plugin=df;plugin_instance=run;type=df_complex;type_instance=free
collectd.df.df_complex.value;ds_name=value;host=raintank-dev;plugin=df;plugin_instance=run;type=df_complex;type_instance=reserved
collectd.df.df_complex.value;ds_name=value;host=raintank-dev;plugin=df;plugin_instance=run;type=df_complex;type_instance=used
collectd.df.df_complex.value;ds_name=value;host=raintank-dev;plugin=df;plugin_instance=run-lock;type=df_complex;type_instance=free
collectd.df.df_complex.value;ds_name=value;host=raintank-dev;plugin=df;plugin_instance=run-lock;type=df_complex;type_instance=reserved
collectd.df.df_complex.value;ds_name=value;host=raintank-dev;plugin=df;plugin_instance=run-lock;type=df_complex;type_instance=used
collectd.df.df_complex.value;ds_name=value;host=raintank-dev;plugin=df;plugin_instance=run-user-1000;type=df_complex;type_instance=free
collectd.df.df_complex.value;ds_name=value;host=raintank-dev;plugin=df;plugin_instance=run-user-1000;type=df_complex;type_instance=reserved
collectd.df.df_complex.value;ds_name=value;host=raintank-dev;plugin=df;plugin_instance=run-user-1000;type=df_complex;type_instance=used
collectd.df.df_complex.value;ds_name=value;host=raintank-dev;plugin=df;plugin_instance=sys-fs-cgroup;type=df_complex;type_instance=free
collectd.df.df_complex.value;ds_name=value;host=raintank-dev;plugin=df;plugin_instance=sys-fs-cgroup;type=df_complex;type_instance=reserved
collectd.df.df_complex.value;ds_name=value;host=raintank-dev;plugin=df;plugin_instance=sys-fs-cgroup;type=df_complex;type_instance=used
collectd.df.df_complex.value;ds_name=value;host=raintank-dev;plugin=df;plugin_instance=var-lib-docker-aufs;type=df_complex;type_instance=free
collectd.df.df_complex.value;ds_name=value;host=raintank-dev;plugin=df;plugin_instance=var-lib-docker-aufs;type=df_complex;type_instance=reserved
collectd.df.df_complex.value;ds_name=value;host=raintank-dev;plugin=df;plugin_instance=var-lib-docker-aufs;type=df_complex;type_instance=used

collectd.disk.disk_io_time.io_time;ds_name=io_time;host=raintank-dev;plugin=disk;plugin_instance=dm-0;type=disk_io_time
collectd.disk.disk_io_time.io_time;ds_name=io_time;host=raintank-dev;plugin=disk;plugin_instance=dm-1;type=disk_io_time
collectd.disk.disk_io_time.io_time;ds_name=io_time;host=raintank-dev;plugin=disk;plugin_instance=sda;type=disk_io_time
collectd.disk.disk_io_time.io_time;ds_name=io_time;host=raintank-dev;plugin=disk;plugin_instance=sda1;type=disk_io_time
collectd.disk.disk_io_time.io_time;ds_name=io_time;host=raintank-dev;plugin=disk;plugin_instance=sda5;type=disk_io_time

collectd.disk.disk_io_time.weighted_io_time;ds_name=weighted_io_time;host=raintank-dev;plugin=disk;plugin_instance=dm-0;type=disk_io_time
collectd.disk.disk_io_time.weighted_io_time;ds_name=weighted_io_time;host=raintank-dev;plugin=disk;plugin_instance=dm-1;type=disk_io_time
collectd.disk.disk_io_time.weighted_io_time;ds_name=weighted_io_time;host=raintank-dev;plugin=disk;plugin_instance=sda;type=disk_io_time
collectd.disk.disk_io_time.weighted_io_time;ds_name=weighted_io_time;host=raintank-dev;plugin=disk;plugin_instance=sda1;type=disk_io_time
collectd.disk.disk_io_time.weighted_io_time;ds_name=weighted_io_time;host=raintank-dev;plugin=disk;plugin_instance=sda5;type=disk_io_time

collectd.disk.disk_merged.read;ds_name=read;host=raintank-dev;plugin=disk;plugin_instance=sda;type=disk_merged
collectd.disk.disk_merged.read;ds_name=read;host=raintank-dev;plugin=disk;plugin_instance=sda1;type=disk_merged
collectd.disk.disk_merged.read;ds_name=read;host=raintank-dev;plugin=disk;plugin_instance=sda5;type=disk_merged

collectd.disk.disk_merged.write;ds_name=write;host=raintank-dev;plugin=disk;plugin_instance=sda;type=disk_merged
collectd.disk.disk_merged.write;ds_name=write;host=raintank-dev;plugin=disk;plugin_instance=sda1;type=disk_merged
collectd.disk.disk_merged.write;ds_name=write;host=raintank-dev;plugin=disk;plugin_instance=sda5;type=disk_merged

collectd.disk.disk_octets.read;ds_name=read;host=raintank-dev;plugin=disk;plugin_instance=dm-0;type=disk_octets
collectd.disk.disk_octets.read;ds_name=read;host=raintank-dev;plugin=disk;plugin_instance=dm-1;type=disk_octets
collectd.disk.disk_octets.read;ds_name=read;host=raintank-dev;plugin=disk;plugin_instance=sda;type=disk_octets
collectd.disk.disk_octets.read;ds_name=read;host=raintank-dev;plugin=disk;plugin_instance=sda1;type=disk_octets
collectd.disk.disk_octets.read;ds_name=read;host=raintank-dev;plugin=disk;plugin_instance=sda2;type=disk_octets
collectd.disk.disk_octets.read;ds_name=read;host=raintank-dev;plugin=disk;plugin_instance=sda5;type=disk_octets

collectd.disk.disk_octets.write;ds_name=write;host=raintank-dev;plugin=disk;plugin_instance=dm-0;type=disk_octets
collectd.disk.disk_octets.write;ds_name=write;host=raintank-dev;plugin=disk;plugin_instance=dm-1;type=disk_octets
collectd.disk.disk_octets.write;ds_name=write;host=raintank-dev;plugin=disk;plugin_instance=sda;type=disk_octets
collectd.disk.disk_octets.write;ds_name=write;host=raintank-dev;plugin=disk;plugin_instance=sda1;type=disk_octets
collectd.disk.disk_octets.write;ds_name=write;host=raintank-dev;plugin=disk;plugin_instance=sda2;type=disk_octets
collectd.disk.disk_octets.write;ds_name=write;host=raintank-dev;plugin=disk;plugin_instance=sda5;type=disk_octets

collectd.disk.disk_ops.read;ds_name=read;host=raintank-dev;plugin=disk;plugin_instance=dm-0;type=disk_ops
collectd.disk.disk_ops.read;ds_name=read;host=raintank-dev;plugin=disk;plugin_instance=dm-1;type=disk_ops
collectd.disk.disk_ops.read;ds_name=read;host=raintank-dev;plugin=disk;plugin_instance=sda;type=disk_ops
collectd.disk.disk_ops.read;ds_name=read;host=raintank-dev;plugin=disk;plugin_instance=sda1;type=disk_ops
collectd.disk.disk_ops.read;ds_name=read;host=raintank-dev;plugin=disk;plugin_instance=sda2;type=disk_ops
collectd.disk.disk_ops.read;ds_name=read;host=raintank-dev;plugin=disk;plugin_instance=sda5;type=disk_ops

collectd.disk.disk_ops.write;ds_name=write;host=raintank-dev;plugin=disk;plugin_instance=dm-0;type=disk_ops
collectd.disk.disk_ops.write;ds_name=write;host=raintank-dev;plugin=disk;plugin_instance=dm-1;type=disk_ops
collectd.disk.disk_ops.write;ds_name=write;host=raintank-dev;plugin=disk;plugin_instance=sda;type=disk_ops
collectd.disk.disk_ops.write;ds_name=write;host=raintank-dev;plugin=disk;plugin_instance=sda1;type=disk_ops
collectd.disk.disk_ops.write;ds_name=write;host=raintank-dev;plugin=disk;plugin_instance=sda2;type=disk_ops
collectd.disk.disk_ops.write;ds_name=write;host=raintank-dev;plugin=disk;plugin_instance=sda5;type=disk_ops

collectd.disk.disk_time.read;ds_name=read;host=raintank-dev;plugin=disk;plugin_instance=dm-0;type=disk_time
collectd.disk.disk_time.read;ds_name=read;host=raintank-dev;plugin=disk;plugin_instance=dm-1;type=disk_time
collectd.disk.disk_time.read;ds_name=read;host=raintank-dev;plugin=disk;plugin_instance=sda;type=disk_time
collectd.disk.disk_time.read;ds_name=read;host=raintank-dev;plugin=disk;plugin_instance=sda1;type=disk_time
collectd.disk.disk_time.read;ds_name=read;host=raintank-dev;plugin=disk;plugin_instance=sda5;type=disk_time

collectd.disk.disk_time.write;ds_name=write;host=raintank-dev;plugin=disk;plugin_instance=dm-0;type=disk_time
collectd.disk.disk_time.write;ds_name=write;host=raintank-dev;plugin=disk;plugin_instance=dm-1;type=disk_time
collectd.disk.disk_time.write;ds_name=write;host=raintank-dev;plugin=disk;plugin_instance=sda;type=disk_time
collectd.disk.disk_time.write;ds_name=write;host=raintank-dev;plugin=disk;plugin_instance=sda1;type=disk_time
collectd.disk.disk_time.write;ds_name=write;host=raintank-dev;plugin=disk;plugin_instance=sda5;type=disk_time

collectd.interface.if_dropped.rx;ds_name=rx;host=raintank-dev;plugin=interface;plugin_instance=br-dbce791310be;type=if_dropped
collectd.interface.if_dropped.rx;ds_name=rx;host=raintank-dev;plugin=interface;plugin_instance=docker0;type=if_dropped
collectd.interface.if_dropped.rx;ds_name=rx;host=raintank-dev;plugin=interface;plugin_instance=enp0s3;type=if_dropped
collectd.interface.if_dropped.rx;ds_name=rx;host=raintank-dev;plugin=interface;plugin_instance=enp0s8;type=if_dropped
collectd.interface.if_dropped.rx;ds_name=rx;host=raintank-dev;plugin=interface;plugin_instance=lo;type=if_dropped

collectd.interface.if_dropped.tx;ds_name=tx;host=raintank-dev;plugin=interface;plugin_instance=br-dbce791310be;type=if_dropped
collectd.interface.if_dropped.tx;ds_name=tx;host=raintank-dev;plugin=interface;plugin_instance=docker0;type=if_dropped
collectd.interface.if_dropped.tx;ds_name=tx;host=raintank-dev;plugin=interface;plugin_instance=enp0s3;type=if_dropped
collectd.interface.if_dropped.tx;ds_name=tx;host=raintank-dev;plugin=interface;plugin_instance=enp0s8;type=if_dropped
collectd.interface.if_dropped.tx;ds_name=tx;host=raintank-dev;plugin=interface;plugin_instance=lo;type=if_dropped

collectd.interface.if_errors.rx;ds_name=rx;host=raintank-dev;plugin=interface;plugin_instance=br-dbce791310be;type=if_errors
collectd.interface.if_errors.rx;ds_name=rx;host=raintank-dev;plugin=interface;plugin_instance=docker0;type=if_errors
collectd.interface.if_errors.rx;ds_name=rx;host=raintank-dev;plugin=interface;plugin_instance=enp0s3;type=if_errors
collectd.interface.if_errors.rx;ds_name=rx;host=raintank-dev;plugin=interface;plugin_instance=enp0s8;type=if_errors
collectd.interface.if_errors.rx;ds_name=rx;host=raintank-dev;plugin=interface;plugin_instance=lo;type=if_errors

collectd.interface.if_errors.tx;ds_name=tx;host=raintank-dev;plugin=interface;plugin_instance=br-dbce791310be;type=if_errors
collectd.interface.if_errors.tx;ds_name=tx;host=raintank-dev;plugin=interface;plugin_instance=docker0;type=if_errors
collectd.interface.if_errors.tx;ds_name=tx;host=raintank-dev;plugin=interface;plugin_instance=enp0s3;type=if_errors
collectd.interface.if_errors.tx;ds_name=tx;host=raintank-dev;plugin=interface;plugin_instance=enp0s8;type=if_errors
collectd.interface.if_errors.tx;ds_name=tx;host=raintank-dev;plugin=interface;plugin_instance=lo;type=if_errors

collectd.interface.if_octets.rx;ds_name=rx;host=raintank-dev;plugin=interface;plugin_instance=br-dbce791310be;type=if_octets
collectd.interface.if_octets.rx;ds_name=rx;host=raintank-dev;plugin=interface;plugin_instance=docker0;type=if_octets
collectd.interface.if_octets.rx;ds_name=rx;host=raintank-dev;plugin=interface;plugin_instance=enp0s3;type=if_octets
collectd.interface.if_octets.rx;ds_name=rx;host=raintank-dev;plugin=interface;plugin_instance=enp0s8;type=if_octets
collectd.interface.if_octets.rx;ds_name=rx;host=raintank-dev;plugin=interface;plugin_instance=lo;type=if_octets

collectd.interface.if_octets.tx;ds_name=tx;host=raintank-dev;plugin=interface;plugin_instance=br-dbce791310be;type=if_octets
collectd.interface.if_octets.tx;ds_name=tx;host=raintank-dev;plugin=interface;plugin_instance=docker0;type=if_octets
collectd.interface.if_octets.tx;ds_name=tx;host=raintank-dev;plugin=interface;plugin_instance=enp0s3;type=if_octets
collectd.interface.if_octets.tx;ds_name=tx;host=raintank-dev;plugin=interface;plugin_instance=enp0s8;type=if_octets
collectd.interface.if_octets.tx;ds_name=tx;host=raintank-dev;plugin=interface;plugin_instance=lo;type=if_octets

collectd.interface.if_packets.rx;ds_name=rx;host=raintank-dev;plugin=interface;plugin_instance=br-dbce791310be;type=if_packets
collectd.interface.if_packets.rx;ds_name=rx;host=raintank-dev;plugin=interface;plugin_instance=docker0;type=if_packets
collectd.interface.if_packets.rx;ds_name=rx;host=raintank-dev;plugin=interface;plugin_instance=enp0s3;type=if_packets
collectd.interface.if_packets.rx;ds_name=rx;host=raintank-dev;plugin=interface;plugin_instance=enp0s8;type=if_packets
collectd.interface.if_packets.rx;ds_name=rx;host=raintank-dev;plugin=interface;plugin_instance=lo;type=if_packets

collectd.interface.if_packets.tx;ds_name=tx;host=raintank-dev;plugin=interface;plugin_instance=br-dbce791310be;type=if_packets
collectd.interface.if_packets.tx;ds_name=tx;host=raintank-dev;plugin=interface;plugin_instance=docker0;type=if_packets
collectd.interface.if_packets.tx;ds_name=tx;host=raintank-dev;plugin=interface;plugin_instance=enp0s3;type=if_packets
collectd.interface.if_packets.tx;ds_name=tx;host=raintank-dev;plugin=interface;plugin_instance=enp0s8;type=if_packets
collectd.interface.if_packets.tx;ds_name=tx;host=raintank-dev;plugin=interface;plugin_instance=lo;type=if_packets

collectd.load.longterm;ds_name=longterm;host=raintank-dev;plugin=load
collectd.load.midterm;ds_name=midterm;host=raintank-dev;plugin=load
collectd.load.shortterm;ds_name=shortterm;host=raintank-dev;plugin=load

collectd.memory.value;ds_name=value;host=raintank-dev;plugin=memory;type_instance=buffered
collectd.memory.value;ds_name=value;host=raintank-dev;plugin=memory;type_instance=cached
collectd.memory.value;ds_name=value;host=raintank-dev;plugin=memory;type_instance=free
collectd.memory.value;ds_name=value;host=raintank-dev;plugin=memory;type_instance=slab_recl
collectd.memory.value;ds_name=value;host=raintank-dev;plugin=memory;type_instance=slab_unrecl
collectd.memory.value;ds_name=value;host=raintank-dev;plugin=memory;type_instance=used
```